### PR TITLE
#900: No longer escapes other characters than " in embed attributes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,6 @@ lazy val article_import= (project in file(".")).
       "org.apache.lucene" % "lucene-test-framework" % "6.4.1" % "test",
       "vc.inreach.aws" % "aws-signing-request-interceptor" % "0.0.16",
       "org.jsoup" % "jsoup" % "1.11.2",
-      "commons-lang" % "commons-lang" % "2.6",
       "com.netaporter" %% "scala-uri" % "0.4.16",
       "org.scalatra" %% "scalatra-scalatest" % Scalatraversion % "test",
       "org.scalatest" %% "scalatest" % ScalaTestVersion % "test",

--- a/src/main/scala/no/ndla/articleimport/service/converters/HTMLCleaner.scala
+++ b/src/main/scala/no/ndla/articleimport/service/converters/HTMLCleaner.scala
@@ -14,7 +14,6 @@ import no.ndla.articleimport.model.domain.ImportStatus
 import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
 import no.ndla.validation.{HtmlTagRules, ResourceType, TagAttributes}
 import org.jsoup.nodes.{Element, Node, TextNode}
-import org.apache.commons.lang.StringEscapeUtils.escapeHtml
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._

--- a/src/main/scala/no/ndla/articleimport/service/converters/HtmlTagGenerator.scala
+++ b/src/main/scala/no/ndla/articleimport/service/converters/HtmlTagGenerator.scala
@@ -7,9 +7,8 @@
 
 package no.ndla.articleimport.service.converters
 
-import no.ndla.validation.{TagAttributes, ResourceType}
+import no.ndla.validation.{ResourceType, TagAttributes}
 import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
-import org.apache.commons.lang.StringEscapeUtils.escapeHtml
 
 trait HtmlTagGenerator {
 
@@ -143,7 +142,7 @@ trait HtmlTagGenerator {
     }
 
     private def buildAttributesString(figureDataAttributeMap: Map[TagAttributes.Value, String]): String =
-      figureDataAttributeMap.toList.sortBy(_._1.toString).map { case (key, value) => s"""$key="${escapeHtml(value.trim)}"""" }.mkString(" ")
+      figureDataAttributeMap.toList.sortBy(_._1.toString).map { case (key, value) => s"""$key="${value.trim.replace("\"", "&quot;")}"""" }.mkString(" ")
 
   }
 

--- a/src/test/scala/no/ndla/articleimport/service/converters/contentbrowser/ImageConverterTest.scala
+++ b/src/test/scala/no/ndla/articleimport/service/converters/contentbrowser/ImageConverterTest.scala
@@ -13,16 +13,14 @@ import no.ndla.articleimport.integration._
 import no.ndla.articleimport.{TestData, TestEnvironment, UnitSuite}
 import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
 import org.mockito.Mockito._
-import org.apache.commons.lang.StringEscapeUtils.escapeHtml
 
 import scala.util.Success
 
 class ImageConverterTest extends UnitSuite with TestEnvironment {
   val nodeId = "1234"
   val altText = "Jente som spiser melom. Grønn bakgrunn, rød melon. Fotografi."
-  val caption = "sample image caption"
-  val escapedAltText = escapeHtml(altText)
-  val escapedCaption = escapeHtml(caption)
+  val caption = "sample \"image\" ; <> æøå ~ é õ caption"
+  val expectedCaption = "sample &quot;image&quot; ; <> æøå ~ é õ caption"
 
   val contentString = s"[contentbrowser ==nid=$nodeId==imagecache=Fullbredde==width===alt=$altText==link===node_link=1==link_type=link_to_content==lightbox_size===remove_fields[76661]=1==remove_fields[76663]=1==remove_fields[76664]=1==remove_fields[76666]=1==insertion===link_title_text= ==link_text=$caption==text_align===css_class=contentbrowser contentbrowser]"
   val contentStringWithLeftMargin = s"[contentbrowser ==nid=$nodeId==imagecache=Fullbredde==width===alt=$altText==link===node_link=1==link_type=link_to_content==lightbox_size===remove_fields[76661]=1==remove_fields[76663]=1==remove_fields[76664]=1==remove_fields[76666]=1==insertion===link_title_text= ==link_text=$caption==text_align===css_class=contentbrowser contentbrowser_margin_left contentbrowser]"
@@ -35,7 +33,7 @@ class ImageConverterTest extends UnitSuite with TestEnvironment {
   val image = ImageMetaInformation("1234", List(ImageTitle("", Some("nb"))), List(ImageAltText("", Some("nb"))), "full.jpg", 1024, "", copyright, ImageTag(List(""), Some("")))
 
   test("That a contentbrowser string of type 'image' returns an HTML img-tag with path to image") {
-    val expectedResult = s"""<$ResourceHtmlEmbedTag data-align="" data-alt="$escapedAltText" data-caption="$escapedCaption" data-resource="image" data-resource_id="1234" data-size="full" />"""
+    val expectedResult = s"""<$ResourceHtmlEmbedTag data-align="" data-alt="$altText" data-caption="$expectedCaption" data-resource="image" data-resource_id="1234" data-size="full" />"""
 
     when(imageApiClient.importImage(nodeId)).thenReturn(Some(image))
 
@@ -46,7 +44,7 @@ class ImageConverterTest extends UnitSuite with TestEnvironment {
   }
 
   test("That the the data-captions attribute is empty if no captions exist") {
-    val expectedResult = s"""<$ResourceHtmlEmbedTag data-align="" data-alt="$escapedAltText" data-caption="" data-resource="image" data-resource_id="1234" data-size="full" />"""
+    val expectedResult = s"""<$ResourceHtmlEmbedTag data-align="" data-alt="$altText" data-caption="" data-resource="image" data-resource_id="1234" data-size="full" />"""
 
     when(imageApiClient.importImage(nodeId)).thenReturn(Some(image))
     val Success((result, requiredLibraries, errors)) = ImageConverter.convert(ContentBrowserString(contentStringEmptyCaption, "nb"), ImportStatus.empty)
@@ -64,7 +62,7 @@ class ImageConverterTest extends UnitSuite with TestEnvironment {
   }
 
   test("That a the html tag contains an alignment attribute with the correct value") {
-    val expectedResult = s"""<$ResourceHtmlEmbedTag data-align="right" data-alt="$escapedAltText" data-caption="$escapedCaption" data-resource="image" data-resource_id="1234" data-size="full" />"""
+    val expectedResult = s"""<$ResourceHtmlEmbedTag data-align="right" data-alt="$altText" data-caption="$expectedCaption" data-resource="image" data-resource_id="1234" data-size="full" />"""
 
     when(imageApiClient.importImage(nodeId)).thenReturn(Some(image))
     val Success((result, requiredLibraries, errors)) = ImageConverter.convert(ContentBrowserString(contentStringWithLeftMargin, "nb"), ImportStatus.empty)

--- a/src/test/scala/no/ndla/articleimport/service/converters/contentbrowser/LenkeConverterTest.scala
+++ b/src/test/scala/no/ndla/articleimport/service/converters/contentbrowser/LenkeConverterTest.scala
@@ -14,7 +14,6 @@ import no.ndla.articleimport.model.domain.ImportStatus
 import no.ndla.validation.ResourceType
 import no.ndla.validation.EmbedTagRules.ResourceHtmlEmbedTag
 import org.mockito.Mockito._
-import org.apache.commons.lang.StringEscapeUtils.escapeHtml
 
 import scala.util.Success
 
@@ -111,13 +110,12 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
   test("That LenkeConverter returns a iframe embed for prezi resources") {
     val preziUrl = "http://prezi.com/123123123"
     val preziSrc = "https://prezi.com/embed/123123123&autoplay=0"
-    val escapedPreziSrc = escapeHtml(preziSrc)
     val preziEmbedCode = s"""<iframe id="iframe_container" frameborder="0" webkitallowfullscreen="" mozallowfullscreen="" allowfullscreen="" width="620" height="451" src="$preziSrc"></iframe>"""
 
     val insertion = "inline"
     val contentString = s"[contentbrowser ==nid=$nodeId==imagecache=Fullbredde==width===alt=$altText==link===node_link=1==link_type=link_to_content==lightbox_size===remove_fields[76661]=1==remove_fields[76663]=1==remove_fields[76664]=1==remove_fields[76666]=1==insertion=$insertion==link_title_text= ==link_text= ==text_align===css_class=contentbrowser contentbrowser]"
     val content = ContentBrowserString(contentString, "nb")
-    val expectedResult = s"""<$ResourceHtmlEmbedTag data-height="451" data-resource="${ResourceType.IframeContent}" data-url="$escapedPreziSrc" data-width="620" />"""
+    val expectedResult = s"""<$ResourceHtmlEmbedTag data-height="451" data-resource="${ResourceType.IframeContent}" data-url="$preziSrc" data-width="620" />"""
 
     when(extractService.getNodeEmbedMeta(nodeId)).thenReturn(Success(MigrationEmbedMeta(Some(preziUrl), Some(preziEmbedCode))))
     val Success((result, _, errors)) = LenkeConverter.convert(content, ImportStatus.empty)
@@ -129,13 +127,12 @@ class LenkeConverterTest extends UnitSuite with TestEnvironment {
   test("That LenkeConverter returns a iframe embed for commoncraft resources") {
     val CcraftUrl = "http://www.commoncraft.com/123123123"
     val CcraftSrc = "https://www.commoncraft.com/embed/db233ba&autoplay=0"
-    val escapedCcraftSrc = escapeHtml(CcraftSrc)
     val CcraftEmbedCode = s"""<iframe id="cc-embed" frameborder="0" width="620" height="451" src="$CcraftSrc" scrolling="false"></iframe>"""
 
     val insertion = "inline"
     val contentString = s"[contentbrowser ==nid=$nodeId==imagecache=Fullbredde==width===alt=$altText==link===node_link=1==link_type=link_to_content==lightbox_size===remove_fields[76661]=1==remove_fields[76663]=1==remove_fields[76664]=1==remove_fields[76666]=1==insertion=$insertion==link_title_text= ==link_text= ==text_align===css_class=contentbrowser contentbrowser]"
     val content = ContentBrowserString(contentString, "nb")
-    val expectedResult = s"""<$ResourceHtmlEmbedTag data-height="451" data-resource="${ResourceType.IframeContent}" data-url="$escapedCcraftSrc" data-width="620" />"""
+    val expectedResult = s"""<$ResourceHtmlEmbedTag data-height="451" data-resource="${ResourceType.IframeContent}" data-url="$CcraftSrc" data-width="620" />"""
 
     when(extractService.getNodeEmbedMeta(nodeId)).thenReturn(Success(MigrationEmbedMeta(Some(CcraftUrl), Some(CcraftEmbedCode))))
     val Success((result, _, errors)) = LenkeConverter.convert(content, ImportStatus.empty)


### PR DESCRIPTION
Since other tags than `&quot;`(") can be interpreted as html in
validation, we no longer escape them, and simply escape manually.

`&oring;`(ø) specifically triggered this error.