### PR TITLE
#1104: SimpleTagConverter no longer validates embed tags with parents

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val article_import = (project in file("."))
     libraryDependencies ++= Seq(
       "ndla" %% "network" % "0.29",
       "ndla" %% "mapping" % "0.6",
-      "ndla" %% "validation" % "0.20",
+      "ndla" %% "validation" % "0.21",
       "joda-time" % "joda-time" % "2.8.2",
       "org.scalatra" %% "scalatra" % Scalatraversion,
       "org.scalatra" %% "scalatra-json" % Scalatraversion,

--- a/src/main/scala/no/ndla/articleimport/service/converters/SimpleTagConverter.scala
+++ b/src/main/scala/no/ndla/articleimport/service/converters/SimpleTagConverter.scala
@@ -43,7 +43,6 @@ trait SimpleTagConverter {
         HtmlValidator.validate("content", e.outerHtml(), validateEmbedTagParent = false).isEmpty
       })
 
-
       val errorMessages = invalidEmbeds.map(embed => {
         val errorToReturn =
           s"Failed to import node with invalid embed. (${embed.outerHtml()})"

--- a/src/main/scala/no/ndla/articleimport/service/converters/SimpleTagConverter.scala
+++ b/src/main/scala/no/ndla/articleimport/service/converters/SimpleTagConverter.scala
@@ -40,10 +40,9 @@ trait SimpleTagConverter {
       val HtmlValidator = new TextValidator(allowHtml = true)
 
       val invalidEmbeds = allEmbeds.filterNot(e => {
-        // Embeds must be validated with parent. "body" is stripped so we don't include that.
-        val embedWithParent = if (e.parent.tagName() != "body") e.parent() else e
-        HtmlValidator.validate("content", embedWithParent.outerHtml()).isEmpty
+        HtmlValidator.validate("content", e.outerHtml(), validateEmbedTagParent = false).isEmpty
       })
+
 
       val errorMessages = invalidEmbeds.map(embed => {
         val errorToReturn =

--- a/src/test/scala/no/ndla/articleimport/service/converters/SimpleTagConverterTest.scala
+++ b/src/test/scala/no/ndla/articleimport/service/converters/SimpleTagConverterTest.scala
@@ -275,4 +275,19 @@ class SimpleTagConverterTest extends UnitSuite with TestEnvironment {
       ))
   }
 
+  test("That embeds that require parents without parent are left untouched") {
+    val content =
+      """<section>
+        |<embed data-resource="related-content" data-url="http://example.com" data-title="Eksempel tittel">
+        |</section>""".stripMargin
+        .replace("\n", "")
+
+    val Success((result, status)) =
+      SimpleTagConverter.convert(TestData.sampleContent.copy(content = content),
+                                 ImportStatus.empty)
+
+    result.content should be (content)
+    status.errors.size should be(0)
+  }
+
 }

--- a/src/test/scala/no/ndla/articleimport/service/converters/SimpleTagConverterTest.scala
+++ b/src/test/scala/no/ndla/articleimport/service/converters/SimpleTagConverterTest.scala
@@ -283,10 +283,9 @@ class SimpleTagConverterTest extends UnitSuite with TestEnvironment {
         .replace("\n", "")
 
     val Success((result, status)) =
-      SimpleTagConverter.convert(TestData.sampleContent.copy(content = content),
-                                 ImportStatus.empty)
+      SimpleTagConverter.convert(TestData.sampleContent.copy(content = content), ImportStatus.empty)
 
-    result.content should be (content)
+    result.content should be(content)
     status.errors.size should be(0)
   }
 

--- a/src/test/scala/no/ndla/articleimport/service/converters/SimpleTagConverterTest.scala
+++ b/src/test/scala/no/ndla/articleimport/service/converters/SimpleTagConverterTest.scala
@@ -275,10 +275,12 @@ class SimpleTagConverterTest extends UnitSuite with TestEnvironment {
       ))
   }
 
-  test("That embeds that require parents without parent are left untouched") {
+  test("That that parents of embeds are not validated") {
     val content =
       """<section>
+        |<div style="border:1;">
         |<embed data-resource="related-content" data-url="http://example.com" data-title="Eksempel tittel">
+        |</div>
         |</section>""".stripMargin
         .replace("\n", "")
 


### PR DESCRIPTION
connects to https://github.com/NDLANO/Issues/issues/1104
Waiting for: https://github.com/NDLANO/validation/pull/21

Validating embed tags with their parents caused a bug in cases where the
parent of an embedtag was invalid because it was yet to be processed by
another converter.