### PR TITLE
Convert h5 to p-strong

### DIFF
--- a/src/main/scala/no/ndla/articleimport/service/converters/HTMLCleaner.scala
+++ b/src/main/scala/no/ndla/articleimport/service/converters/HTMLCleaner.scala
@@ -25,8 +25,10 @@ trait HTMLCleaner {
   val htmlCleaner: HTMLCleaner
 
   class HTMLCleaner extends ConverterModule with LazyLogging {
+
     override def convert(content: LanguageContent, importStatus: ImportStatus): Try[(LanguageContent, ImportStatus)] = {
       val element = stringToJsoupDocument(content.content)
+      convertH5sToPStrong(element)
       val illegalTags = unwrapIllegalTags(element)
         .map(x => s"Illegal tag(s) removed: $x")
         .distinct
@@ -53,7 +55,6 @@ trait HTMLCleaner {
       unwrapNestedPs(element)
 
       convertH3sToH2s(element)
-
       convertAsideH2sToH1(element)
       val finalCleanedDocument = allContentMustBeWrappedInSectionBlocks(element)
 
@@ -65,6 +66,10 @@ trait HTMLCleaner {
                       metaDescription = metaDescription,
                       ingress = ingress),
          importStatus.addMessages(illegalTags ++ illegalAttributes)))
+    }
+
+    private def convertH5sToPStrong(element: Element): Unit = {
+      element.select("h5").asScala.foreach(_.tagName("strong").wrap("p"))
     }
 
     private def convertAsideH2sToH1(element: Element): Unit = {

--- a/src/test/scala/no/ndla/articleimport/service/converters/HTMLCleanerTest.scala
+++ b/src/test/scala/no/ndla/articleimport/service/converters/HTMLCleanerTest.scala
@@ -919,4 +919,16 @@ class HTMLCleanerTest extends UnitSuite with TestEnvironment {
     result.requiredLibraries.size should equal(0)
   }
 
+  test("H5's should be converted to p->strong") {
+    val initialContent = TestData.sampleContent.copy(content =
+      """<section><h5>Hei</h5><p>More stuff down here</p></section>""")
+    val expectedResult =
+      "<section><p><strong>Hei</strong></p><p>More stuff down here</p></section>"
+    val Success((result, _)) =
+      htmlCleaner.convert(initialContent, defaultImportStatus)
+
+    result.content should equal(expectedResult)
+    result.requiredLibraries.size should equal(0)
+  }
+
 }


### PR DESCRIPTION
Fixes when h5 is used as table header text.